### PR TITLE
Allow robot to be up to 1 m away from target.

### DIFF
--- a/example/src/systemTest/java/frc/robot/SystemTestRobot.java
+++ b/example/src/systemTest/java/frc/robot/SystemTestRobot.java
@@ -133,7 +133,7 @@ public class SystemTestRobot extends Robot {
             var diff = new Vector<N3>(expectedPos.minus(actualPos));
             var distance = Math.sqrt(diff.elementTimes(diff).elementSum());
 
-            assertEquals("Robot close to target position", 0.0, distance, 0.2);
+            assertEquals("Robot close to target position", 0.0, distance, 1.0);
 
             // Call endCompetition() to end the test and report success.
             // NOTE: throwing an exception will end the test and report failure.


### PR DESCRIPTION
Prevents occasional CI failures caused by dead reckoning nature of test.