### PR TITLE
Add-support-for-linear-motors

### DIFF
--- a/example/src/main/java/frc/robot/Robot.java
+++ b/example/src/main/java/frc/robot/Robot.java
@@ -30,6 +30,7 @@ public class Robot extends TimedRobot {
   private PWMMotorController m_leftFollower;
   private PWMMotorController m_rightMaster;
   private PWMMotorController m_rightFollower;
+  private PWMMotorController m_elevator;
 
   /**
    * This function is run when the robot is first started up and should be
@@ -47,6 +48,8 @@ public class Robot extends TimedRobot {
     m_rightMaster.setInverted(true);
 
     m_robotDrive = new DifferentialDrive(m_leftMaster, m_rightMaster);
+
+    m_elevator = new PWMVictorSPX(4);
   }
 
   public void close() {
@@ -55,6 +58,7 @@ public class Robot extends TimedRobot {
     m_leftFollower.close();
     m_rightMaster.close();
     m_rightFollower.close();
+    m_elevator.close();
   }
 
   /**
@@ -74,6 +78,7 @@ public class Robot extends TimedRobot {
     // Drive for 2 seconds
     if (m_timer.get() < 2.0) {
       m_robotDrive.arcadeDrive(0.5, 0.0); // drive forwards half speed
+      m_elevator.set(0.1);
     } else {
       m_robotDrive.stopMotor(); // stop robot
     }

--- a/example/src/systemTest/java/frc/robot/SystemTestRobot.java
+++ b/example/src/systemTest/java/frc/robot/SystemTestRobot.java
@@ -57,7 +57,7 @@ public class SystemTestRobot {
 
     private volatile boolean stoppedTryingToTurn = false;
 
-    // @Test
+    @Test
     void testCanBeRotatedInPlaceInTeleop()
             throws TimeoutException, FileNotFoundException {
         try (var robot = new Robot();

--- a/example/src/systemTest/java/frc/robot/SystemTestRobot.java
+++ b/example/src/systemTest/java/frc/robot/SystemTestRobot.java
@@ -18,7 +18,7 @@ import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 public class SystemTestRobot {
 
     @Test
-    void testDrivesToLocationInAutonomous()
+    void testDrivesToLocationAndElevatesInAutonomous()
             throws TimeoutException, FileNotFoundException {
         try (var robot = new Robot();
                 var manager =
@@ -38,7 +38,11 @@ public class SystemTestRobot {
                 assertEquals(0.0,
                         s.position("ROBOT")
                                 .getDistance(new Translation3d(2.6, 0, 0)),
-                        1.0, "Robot close to target position");
+                        0.1, "Robot close to target position");
+                assertEquals(0.0,
+                        s.position("ELEVATOR")
+                                .getDistance(new Translation3d(2.6, 0, 0.9)),
+                        0.1, "Elevator close to target position");
                 assertEquals(0.0,
                         s.velocity("ROBOT")
                                 .getDistance(new Translation3d(0, 0, 0)),
@@ -53,7 +57,7 @@ public class SystemTestRobot {
 
     private volatile boolean stoppedTryingToTurn = false;
 
-    @Test
+    // @Test
     void testCanBeRotatedInPlaceInTeleop()
             throws TimeoutException, FileNotFoundException {
         try (var robot = new Robot();

--- a/example/src/systemTest/java/frc/robot/SystemTestRobot.java
+++ b/example/src/systemTest/java/frc/robot/SystemTestRobot.java
@@ -38,11 +38,11 @@ public class SystemTestRobot {
                 assertEquals(0.0,
                         s.position("ROBOT")
                                 .getDistance(new Translation3d(2.6, 0, 0)),
-                        0.1, "Robot close to target position");
+                        0.2, "Robot close to target position");
                 assertEquals(0.0,
                         s.position("ELEVATOR")
                                 .getDistance(new Translation3d(2.6, 0, 0.9)),
-                        0.1, "Elevator close to target position");
+                        0.2, "Elevator close to target position");
                 assertEquals(0.0,
                         s.velocity("ROBOT")
                                 .getDistance(new Translation3d(0, 0, 0)),

--- a/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/mediators/CANMotorMediator.java
+++ b/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/mediators/CANMotorMediator.java
@@ -30,11 +30,15 @@ public class CANMotorMediator implements Runnable {
     private double neutralDeadband = 0.04;
 
     /**
-     * Creates a new MotorMediator
+     * Creates a new CANMotorMediator
+     * 
      * @param motor the Webots motor to link to
      * @param simDevice the SimDeviceSim to use
      * @param motorConstants the motor constants to use
-     * @param gearing the gear ratio to use
+     * @param gearing the gear reduction ratio to use. When used with a LinearMotor this includes
+     *        the conversion between meters and radians.
+     * @param inverted whether positive voltage should result in CW rotation (true) or CCW rotation
+     *        (false).
      */
     public CANMotorMediator(Motor motor, CANMotorSim simDevice, DCMotor motorConstants, double gearing, boolean inverted) {
         this.motor = motor;

--- a/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/mediators/PWMMotorMediator.java
+++ b/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/mediators/PWMMotorMediator.java
@@ -14,6 +14,17 @@ public class PWMMotorMediator {
     public final DCMotor motorConstants;
     public final PWMSim motorDevice;
 
+    /**
+     * Creates a new PWMMotorMediator
+     * 
+     * @param motor the Webots motor to link to
+     * @param simDevice the SimDeviceSim to use
+     * @param motorConstants the motor constants to use
+     * @param gearing the gear reduction ratio to use. When used with a LinearMotor this includes
+     *        the conversion between meters and radians.
+     * @param inverted whether positive voltage should result in CW rotation (true) or CCW rotation
+     *        (false).
+     */
     public PWMMotorMediator(Motor motor, PWMSim simDevice, DCMotor motorConstants, double gearing, boolean inverted) {
         this.motor = motor;
         this.motorDevice = simDevice;

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015LinearMotor.proto
@@ -16,9 +16,7 @@ PROTO AndyMark9015LinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('AndyMark9015') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015LinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of an AndyMark 9015 motor.
+PROTO AndyMark9015LinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('AndyMark9015') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015Motor.proto
@@ -15,9 +15,7 @@ PROTO AndyMark9015Motor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('AndyMark9015') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMark9015Motor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO AndyMark9015Motor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.36
-        stallCurrentAmps 71
-        freeCurrentAmps 3.7
-        freeSpeedRPM 14270
-        sound IS sound
+        %<= motor.getDef('AndyMark9015') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125LinearMotor.proto
@@ -16,9 +16,7 @@ PROTO AndyMarkRs775_125LinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('Rs775_125') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125LinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of an AndyMark Rs 775_125 motor.
+PROTO AndyMarkRs775_125LinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('Rs775_125') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125Motor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO AndyMarkRs775_125Motor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.28
-        stallCurrentAmps 18
-        freeCurrentAmps 1.6
-        freeSpeedRPM 5800
-        sound IS sound
+        %<= motor.getDef('Rs775_125') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/AndyMarkRs775_125Motor.proto
@@ -15,9 +15,7 @@ PROTO AndyMarkRs775_125Motor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('Rs775_125') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/BagLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BagLinearMotor.proto
@@ -16,9 +16,7 @@ PROTO BagLinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('Bag') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/BagLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BagLinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of a Bag Motor
+PROTO BagLinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('Bag') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/BagMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BagMotor.proto
@@ -15,9 +15,7 @@ PROTO BagMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('Bag') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/BagMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BagMotor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO BagMotor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.43
-        stallCurrentAmps 53
-        freeCurrentAmps 1.8
-        freeSpeedRPM 13180
-        sound IS sound
+        %<= motor.getDef('Bag') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550LinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of a Banebots Rs 550 motor.
+PROTO BanebotsRs550LinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('BanebotsRs550') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550LinearMotor.proto
@@ -16,9 +16,7 @@ PROTO BanebotsRs550LinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('BanebotsRs550') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550Motor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO BanebotsRs550Motor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.38
-        stallCurrentAmps 84
-        freeCurrentAmps 0.4
-        freeSpeedRPM 19000
-        sound IS sound
+        %<= motor.getDef('BanebotsRs550') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs550Motor.proto
@@ -15,9 +15,7 @@ PROTO BanebotsRs550Motor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('BanebotsRs550') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775LinearMotor.proto
@@ -16,9 +16,7 @@ PROTO BanebotsRs775LinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('BanebotsRs775') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775LinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of a Banebots Rs 775 motor.
+PROTO BanebotsRs775LinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('BanebotsRs775') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775Motor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO BanebotsRs775Motor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.72
-        stallCurrentAmps 97
-        freeCurrentAmps 2.7
-        freeSpeedRPM 13050
-        sound IS sound
+        %<= motor.getDef('BanebotsRs775') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/BanebotsRs775Motor.proto
@@ -15,9 +15,7 @@ PROTO BanebotsRs775Motor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('BanebotsRs775') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/CIMLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/CIMLinearMotor.proto
@@ -16,9 +16,7 @@ PROTO CIMLinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('CIM') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/CIMLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/CIMLinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of a CIM motor.
+PROTO CIMLinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('CIM') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/CIMMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/CIMMotor.proto
@@ -15,9 +15,7 @@ PROTO CIMMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('CIM') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/CIMMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/CIMMotor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO CIMMotor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 2.42
-        stallCurrentAmps 133
-        freeCurrentAmps 2.7
-        freeSpeedRPM 5310
-        sound IS sound
+        %<= motor.getDef('CIM') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/Falcon500LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Falcon500LinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+# A WPIMotorBase with the parameters of a Falcon 500 motor.
+PROTO Falcon500LinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('Falcon500') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/Falcon500LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Falcon500LinearMotor.proto
@@ -16,9 +16,7 @@ PROTO Falcon500LinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('Falcon500') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/Falcon500Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Falcon500Motor.proto
@@ -15,9 +15,7 @@ PROTO Falcon500Motor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('Falcon500') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/Falcon500Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Falcon500Motor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO Falcon500Motor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 4.69
-        stallCurrentAmps 257
-        freeCurrentAmps 1.5
-        freeSpeedRPM 6380
-        sound IS sound
+        %<= motor.getDef('Falcon500') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/MiniCIMLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/MiniCIMLinearMotor.proto
@@ -16,9 +16,7 @@ PROTO MiniCIMLinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('MiniCIM') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/MiniCIMLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/MiniCIMLinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
 # A WPIMotorBase with the parameters of a Mini CIM motor.
-PROTO MiniCIMMotor [
+PROTO MiniCIMLinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO MiniCIMMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
+    WPILinearMotorBase {
         %<= motor.getDef('MiniCIM') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/MiniCIMMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/MiniCIMMotor.proto
@@ -15,9 +15,7 @@ PROTO MiniCIMMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('MiniCIM') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEO550LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEO550LinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
-    field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
-    field SFInt32 port 0
+# A WPIMotorBase with the parameters of a NEO 550 motor.
+PROTO NEO550LinearMotor [
+    field SFInt32 id 0
+    field SFString{"Spark Max", "PWM"} controllerType "Spark Max"
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('NEO550') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEO550LinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEO550LinearMotor.proto
@@ -16,9 +16,7 @@ PROTO NEO550LinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('NEO550') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEO550Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEO550Motor.proto
@@ -15,9 +15,7 @@ PROTO NEO550Motor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('NEO550') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEO550Motor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEO550Motor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO NEO550Motor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS id
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.97
-        stallCurrentAmps 100
-        freeCurrentAmps 1.4
-        freeSpeedRPM 11000
-        sound IS sound
+        %<= motor.getDef('NEO550') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEOLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEOLinearMotor.proto
@@ -16,9 +16,7 @@ PROTO NEOLinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('NEO') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEOLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEOLinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Mini CIM motor.
-PROTO MiniCIMMotor [
-    field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
-    field SFInt32 port 0
+# A WPIMotorBase with the parameters of a NEO motor.
+PROTO NEOLinearMotor [
+    field SFInt32 id 0
+    field SFString{"Spark Max", "PWM"} controllerType "Spark Max"
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO MiniCIMMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('MiniCIM') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('NEO') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEOMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEOMotor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO NEOMotor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS id
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 2.6
-        stallCurrentAmps 105
-        freeCurrentAmps 1.8
-        freeSpeedRPM 5676
-        sound IS sound
+        %<= motor.getDef('NEO') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/NEOMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/NEOMotor.proto
@@ -15,9 +15,7 @@ PROTO NEOMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('NEO') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
@@ -17,7 +17,7 @@ EXTERNPROTO "../protos/SparkMaxAnalogSensor.proto"
 EXTERNPROTO "../protos/WPIQuadratureEncoder.proto"
 EXTERNPROTO "../protos/CANCoder.proto"
 
-# A RotationalMotor with the properties necessary to construct a WPILib DCMotor
+# A HingeJoint powered by an FRC-legal motor
 PROTO PoweredHingeJoint [
     field MFNode{
       NEOMotor{}, NEO550Motor{}, Falcon500Motor{}, CIMMotor{}, MiniCIMMotor{}, Vex775ProMotor{}, RomiBuiltinMotor{}, BanebotsRs550Motor{}, BanebotsRs775Motor{},

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
@@ -36,7 +36,6 @@ PROTO PoweredHingeJoint [
     let encoderDevice = null;
     for (let i = 0; i < devices.length; i++) {
         let node_name = devices[i].node_name;
-        if (node_name === null) continue;
         if (node_name === "Brake") {
             hasBrake = true;
         } else if (node_name.endsWith("Motor")) {
@@ -47,14 +46,14 @@ PROTO PoweredHingeJoint [
     }
     assert(hasBrake, "PoweredHingeJoint is missing the required Brake device!");
     assert(motorDevice !== null, "PoweredHingeJoint is missing the required motor device!");
-    let motorType = motorDevice.node_name;
-    let controllerType = motorDevice.fields.controllerType.value;
-    if (controllerType.startsWith("Spark")) {
+    let motorType = motorDevice?.node_name;
+    let controllerType = motorDevice?.fields.controllerType.value;
+    if (controllerType?.startsWith("Spark")) {
         assert(encoderDevice !== null, "PoweredHingeJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
             + "Consider adding a REVBuiltinEncoder.");
-    } else if (controllerType === "PWM" && encoderDevice !== null) {
-        let encoderType = encoderDevice.node_name;
-        assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredHingeJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
+    } else if (controllerType === "PWM") {
+        let encoderType = encoderDevice?.node_name;
+        assert(!encoderType?.endsWith("BuiltinEncoder"), "PoweredHingeJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
     }
     >%
     HingeJoint {

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
@@ -20,45 +20,44 @@ EXTERNPROTO "../protos/CANCoder.proto"
 # A HingeJoint powered by an FRC-legal motor
 PROTO PoweredHingeJoint [
     field MFNode{
-      NEOMotor{}, NEO550Motor{}, Falcon500Motor{}, CIMMotor{}, MiniCIMMotor{}, Vex775ProMotor{}, RomiBuiltinMotor{}, BanebotsRs550Motor{}, BanebotsRs775Motor{},
-      REVBuiltinEncoder{}, SparkMaxAbsoluteEncoder{}, SparkMaxAlternateEncoder{}, SparkMaxAnalogSensor{}, WPIQuadratureEncoder{}, CANCoder{},
-      Brake{}
+        NEOMotor{}, NEO550Motor{}, Falcon500Motor{}, CIMMotor{}, MiniCIMMotor{}, Vex775ProMotor{}, RomiBuiltinMotor{}, BanebotsRs550Motor{}, BanebotsRs775Motor{},
+        REVBuiltinEncoder{}, SparkMaxAbsoluteEncoder{}, SparkMaxAlternateEncoder{}, SparkMaxAnalogSensor{}, WPIQuadratureEncoder{}, CANCoder{},
+        Brake{}
     } devices [NEOMotor{} REVBuiltinEncoder{} Brake{}]
     field SFNode{Solid{}} endPoint Solid{}
     field SFNode{HingeJointParameters{}} jointParameters HingeJointParameters{}
 ]
 {
-%<
-import {info,assert} from 'wbutility.js'; 
-let devices = fields.devices.value;
-let hasBrake = false;
-let motorDevice = null;
-let encoderDevice = null;
-for (let i = 0; i < devices.length; i++) {
-  if (devices[i].node_name == "Brake") {
-    hasBrake = true;
-  } else if (devices[i].node_name.endsWith("Motor")) {
-    motorDevice = devices[i];
-  } else if (devices[i].node_name.endsWith("Encoder")) {
-    encoderDevice = devices[i];
-  }
-}
-assert(hasBrake, "PoweredHingeJoint is missing the required Brake device!");
-assert(motorDevice != null, "PoweredHingeJoint is missing the required motor device!");
-let motorType = motorDevice.node_name;
-let controllerType = motorDevice.fields.controllerType.value;
-if (controllerType.startsWith("Spark")) {
-  assert(encoderDevice != null, "PoweredHingeJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
-    + "Consider adding a REVBuiltinEncoder.");
-} else if (controllerType == "PWM" && encoderDevice != null) {
-  let encoderType = encoderDevice.node_name;
-  assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredHingeJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
-}
-
->%
+    %<
+    import {info,assert} from 'wbutility.js';
+    let devices = fields.devices.value;
+    let hasBrake = false;
+    let motorDevice = null;
+    let encoderDevice = null;
+    for (let i = 0; i < devices.length; i++) {
+        if (devices[i].node_name == "Brake") {
+            hasBrake = true;
+        } else if (devices[i].node_name.endsWith("Motor")) {
+            motorDevice = devices[i];
+        } else if (devices[i].node_name.endsWith("Encoder")) {
+            encoderDevice = devices[i];
+        }
+    }
+    assert(hasBrake, "PoweredHingeJoint is missing the required Brake device!");
+    assert(motorDevice != null, "PoweredHingeJoint is missing the required motor device!");
+    let motorType = motorDevice.node_name;
+    let controllerType = motorDevice.fields.controllerType.value;
+    if (controllerType.startsWith("Spark")) {
+        assert(encoderDevice != null, "PoweredHingeJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
+            + "Consider adding a REVBuiltinEncoder.");
+    } else if (controllerType == "PWM" && encoderDevice != null) {
+        let encoderType = encoderDevice.node_name;
+        assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredHingeJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
+    }
+    >%
     HingeJoint {
         device IS devices
         endPoint IS endPoint
         jointParameters IS jointParameters
-    }        
+    }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredHingeJoint.proto
@@ -35,22 +35,24 @@ PROTO PoweredHingeJoint [
     let motorDevice = null;
     let encoderDevice = null;
     for (let i = 0; i < devices.length; i++) {
-        if (devices[i].node_name == "Brake") {
+        let node_name = devices[i].node_name;
+        if (node_name === null) continue;
+        if (node_name === "Brake") {
             hasBrake = true;
-        } else if (devices[i].node_name.endsWith("Motor")) {
+        } else if (node_name.endsWith("Motor")) {
             motorDevice = devices[i];
-        } else if (devices[i].node_name.endsWith("Encoder")) {
+        } else if (node_name.endsWith("Encoder")) {
             encoderDevice = devices[i];
         }
     }
     assert(hasBrake, "PoweredHingeJoint is missing the required Brake device!");
-    assert(motorDevice != null, "PoweredHingeJoint is missing the required motor device!");
+    assert(motorDevice !== null, "PoweredHingeJoint is missing the required motor device!");
     let motorType = motorDevice.node_name;
     let controllerType = motorDevice.fields.controllerType.value;
     if (controllerType.startsWith("Spark")) {
-        assert(encoderDevice != null, "PoweredHingeJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
+        assert(encoderDevice !== null, "PoweredHingeJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
             + "Consider adding a REVBuiltinEncoder.");
-    } else if (controllerType == "PWM" && encoderDevice != null) {
+    } else if (controllerType === "PWM" && encoderDevice !== null) {
         let encoderType = encoderDevice.node_name;
         assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredHingeJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
@@ -35,22 +35,24 @@ PROTO PoweredSliderJoint [
     let motorDevice = null;
     let encoderDevice = null;
     for (let i = 0; i < devices.length; i++) {
-        if (devices[i].node_name == "Brake") {
+        let node_name = devices[i].node_name;
+        if (node_name === null) continue;
+        if (node_name === "Brake") {
             hasBrake = true;
-        } else if (devices[i].node_name.endsWith("Motor")) {
+        } else if (node_name.endsWith("Motor")) {
             motorDevice = devices[i];
-        } else if (devices[i].node_name.endsWith("Encoder")) {
+        } else if (node_name.endsWith("Encoder")) {
             encoderDevice = devices[i];
         }
     }
     assert(hasBrake, "PoweredSliderJoint is missing the required Brake device!");
-    assert(motorDevice != null, "PoweredSliderJoint is missing the required motor device!");
+    assert(motorDevice !== null, "PoweredSliderJoint is missing the required motor device!");
     let motorType = motorDevice.node_name;
     let controllerType = motorDevice.fields.controllerType.value;
     if (controllerType.startsWith("Spark")) {
-        assert(encoderDevice != null, "PoweredSliderJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
+        assert(encoderDevice !== null, "PoweredSliderJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
             + "Consider adding a REVBuiltinEncoder.");
-    } else if (controllerType == "PWM" && encoderDevice != null) {
+    } else if (controllerType === "PWM" && encoderDevice !== null) {
         let encoderType = encoderDevice.node_name;
         assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredSliderJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
@@ -36,7 +36,6 @@ PROTO PoweredSliderJoint [
     let encoderDevice = null;
     for (let i = 0; i < devices.length; i++) {
         let node_name = devices[i].node_name;
-        if (node_name === null) continue;
         if (node_name === "Brake") {
             hasBrake = true;
         } else if (node_name.endsWith("Motor")) {
@@ -47,14 +46,14 @@ PROTO PoweredSliderJoint [
     }
     assert(hasBrake, "PoweredSliderJoint is missing the required Brake device!");
     assert(motorDevice !== null, "PoweredSliderJoint is missing the required motor device!");
-    let motorType = motorDevice.node_name;
-    let controllerType = motorDevice.fields.controllerType.value;
-    if (controllerType.startsWith("Spark")) {
+    let motorType = motorDevice?.node_name;
+    let controllerType = motorDevice?.fields.controllerType.value;
+    if (controllerType?.startsWith("Spark")) {
         assert(encoderDevice !== null, "PoweredSliderJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
             + "Consider adding a REVBuiltinEncoder.");
-    } else if (controllerType === "PWM" && encoderDevice !== null) {
-        let encoderType = encoderDevice.node_name;
-        assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredSliderJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
+    } else if (controllerType === "PWM") {
+        let encoderType = encoderDevice?.node_name;
+        assert(!encoderType?.endsWith("BuiltinEncoder"), "PoweredSliderJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
     }
     >%
     SliderJoint {

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
@@ -20,45 +20,44 @@ EXTERNPROTO "../protos/CANCoder.proto"
 # A SliderJoint powered by an FRC-legal motor
 PROTO PoweredSliderJoint [
     field MFNode{
-      NEOLinearMotor{}, NEO550LinearMotor{}, Falcon500LinearMotor{}, CIMLinearMotor{}, MiniCIMLinearMotor{}, Vex775ProLinearMotor{}, RomiBuiltinLinearMotor{}, BanebotsRs550LinearMotor{}, BanebotsRs775LinearMotor{},
-      REVBuiltinEncoder{}, SparkMaxAbsoluteEncoder{}, SparkMaxAlternateEncoder{}, SparkMaxAnalogSensor{}, WPIQuadratureEncoder{}, CANCoder{},
-      Brake{}
+        NEOLinearMotor{}, NEO550LinearMotor{}, Falcon500LinearMotor{}, CIMLinearMotor{}, MiniCIMLinearMotor{}, Vex775ProLinearMotor{}, RomiBuiltinLinearMotor{}, BanebotsRs550LinearMotor{}, BanebotsRs775LinearMotor{},
+        REVBuiltinEncoder{}, SparkMaxAbsoluteEncoder{}, SparkMaxAlternateEncoder{}, SparkMaxAnalogSensor{}, WPIQuadratureEncoder{}, CANCoder{},
+        Brake{}
     } devices [NEOLinearMotor{} REVBuiltinEncoder{} Brake{}]
     field SFNode{Solid{}} endPoint Solid{}
     field SFNode{JointParameters{}} jointParameters JointParameters{}
 ]
 {
-%<
-import {info,assert} from 'wbutility.js'; 
-let devices = fields.devices.value;
-let hasBrake = false;
-let motorDevice = null;
-let encoderDevice = null;
-for (let i = 0; i < devices.length; i++) {
-  if (devices[i].node_name == "Brake") {
-    hasBrake = true;
-  } else if (devices[i].node_name.endsWith("Motor")) {
-    motorDevice = devices[i];
-  } else if (devices[i].node_name.endsWith("Encoder")) {
-    encoderDevice = devices[i];
-  }
-}
-assert(hasBrake, "PoweredSliderJoint is missing the required Brake device!");
-assert(motorDevice != null, "PoweredSliderJoint is missing the required motor device!");
-let motorType = motorDevice.node_name;
-let controllerType = motorDevice.fields.controllerType.value;
-if (controllerType.startsWith("Spark")) {
-  assert(encoderDevice != null, "PoweredSliderJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
-    + "Consider adding a REVBuiltinEncoder.");
-} else if (controllerType == "PWM" && encoderDevice != null) {
-  let encoderType = encoderDevice.node_name;
-  assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredSliderJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
-}
-
->%
+    %<
+    import {info,assert} from 'wbutility.js';
+    let devices = fields.devices.value;
+    let hasBrake = false;
+    let motorDevice = null;
+    let encoderDevice = null;
+    for (let i = 0; i < devices.length; i++) {
+        if (devices[i].node_name == "Brake") {
+            hasBrake = true;
+        } else if (devices[i].node_name.endsWith("Motor")) {
+            motorDevice = devices[i];
+        } else if (devices[i].node_name.endsWith("Encoder")) {
+            encoderDevice = devices[i];
+        }
+    }
+    assert(hasBrake, "PoweredSliderJoint is missing the required Brake device!");
+    assert(motorDevice != null, "PoweredSliderJoint is missing the required motor device!");
+    let motorType = motorDevice.node_name;
+    let controllerType = motorDevice.fields.controllerType.value;
+    if (controllerType.startsWith("Spark")) {
+        assert(encoderDevice != null, "PoweredSliderJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
+            + "Consider adding a REVBuiltinEncoder.");
+    } else if (controllerType == "PWM" && encoderDevice != null) {
+        let encoderType = encoderDevice.node_name;
+        assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredSliderJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
+    }
+    >%
     SliderJoint {
         device IS devices
         endPoint IS endPoint
         jointParameters IS jointParameters
-    }        
+    }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/PoweredSliderJoint.proto
@@ -1,0 +1,64 @@
+#VRML_SIM R2023b utf8
+# template language: javascript
+
+EXTERNPROTO "../protos/NEOLinearMotor.proto"
+EXTERNPROTO "../protos/NEO550LinearMotor.proto"
+EXTERNPROTO "../protos/Falcon500LinearMotor.proto"
+EXTERNPROTO "../protos/CIMLinearMotor.proto"
+EXTERNPROTO "../protos/MiniCIMLinearMotor.proto"
+EXTERNPROTO "../protos/Vex775ProLinearMotor.proto"
+EXTERNPROTO "../protos/RomiBuiltinLinearMotor.proto"
+EXTERNPROTO "../protos/BanebotsRs550LinearMotor.proto"
+EXTERNPROTO "../protos/BanebotsRs775LinearMotor.proto"
+EXTERNPROTO "../protos/REVBuiltinEncoder.proto"
+EXTERNPROTO "../protos/SparkMaxAbsoluteEncoder.proto"
+EXTERNPROTO "../protos/SparkMaxAlternateEncoder.proto"
+EXTERNPROTO "../protos/SparkMaxAnalogSensor.proto"
+EXTERNPROTO "../protos/WPIQuadratureEncoder.proto"
+EXTERNPROTO "../protos/CANCoder.proto"
+
+# A SliderJoint powered by an FRC-legal motor
+PROTO PoweredSliderJoint [
+    field MFNode{
+      NEOLinearMotor{}, NEO550LinearMotor{}, Falcon500LinearMotor{}, CIMLinearMotor{}, MiniCIMLinearMotor{}, Vex775ProLinearMotor{}, RomiBuiltinLinearMotor{}, BanebotsRs550LinearMotor{}, BanebotsRs775LinearMotor{},
+      REVBuiltinEncoder{}, SparkMaxAbsoluteEncoder{}, SparkMaxAlternateEncoder{}, SparkMaxAnalogSensor{}, WPIQuadratureEncoder{}, CANCoder{},
+      Brake{}
+    } devices [NEOLinearMotor{} REVBuiltinEncoder{} Brake{}]
+    field SFNode{Solid{}} endPoint Solid{}
+    field SFNode{JointParameters{}} jointParameters JointParameters{}
+]
+{
+%<
+import {info,assert} from 'wbutility.js'; 
+let devices = fields.devices.value;
+let hasBrake = false;
+let motorDevice = null;
+let encoderDevice = null;
+for (let i = 0; i < devices.length; i++) {
+  if (devices[i].node_name == "Brake") {
+    hasBrake = true;
+  } else if (devices[i].node_name.endsWith("Motor")) {
+    motorDevice = devices[i];
+  } else if (devices[i].node_name.endsWith("Encoder")) {
+    encoderDevice = devices[i];
+  }
+}
+assert(hasBrake, "PoweredSliderJoint is missing the required Brake device!");
+assert(motorDevice != null, "PoweredSliderJoint is missing the required motor device!");
+let motorType = motorDevice.node_name;
+let controllerType = motorDevice.fields.controllerType.value;
+if (controllerType.startsWith("Spark")) {
+  assert(encoderDevice != null, "PoweredSliderJoint is using a " + controllerType + " motor controller but is missing the required encoder device! "
+    + "Consider adding a REVBuiltinEncoder.");
+} else if (controllerType == "PWM" && encoderDevice != null) {
+  let encoderType = encoderDevice.node_name;
+  assert(!encoderType.endsWith("BuiltinEncoder"), "PoweredSliderJoint is using a " + controllerType + " motor controller, so a built-in encoder is not allowed!");
+}
+
+>%
+    SliderJoint {
+        device IS devices
+        endPoint IS endPoint
+        jointParameters IS jointParameters
+    }        
+}

--- a/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinLinearMotor.proto
@@ -15,9 +15,7 @@ PROTO RomiBuiltinLinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('RomiBuiltin') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinLinearMotor.proto
@@ -4,13 +4,13 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
-# A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
-    field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
+# A WPIMotorBase with the parameters of a Romi Bultin Motor
+PROTO RomiBuiltinLinearMotor [
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +18,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('RomiBuiltin') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinMotor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -13,16 +14,10 @@ PROTO RomiBuiltinMotor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType "PWM"
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 4.5
-        stallTorqueNewtonMeters 0.1765
-        stallCurrentAmps 1.25
-        freeCurrentAmps 0.13
-        freeSpeedRPM 150
-        sound IS sound
+        %<= motor.getDef('RomiBuiltin') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/RomiBuiltinMotor.proto
@@ -14,9 +14,7 @@ PROTO RomiBuiltinMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('RomiBuiltin') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/Vex775ProLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Vex775ProLinearMotor.proto
@@ -20,6 +20,6 @@ PROTO Vex775ProLinearMotor [
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
     WPILinearMotorBase {
-        %<= motor.getDef('Vex755Pro') >%
+        %<= motor.getDef('Vex775Pro') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/Vex775ProLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Vex775ProLinearMotor.proto
@@ -16,9 +16,7 @@ PROTO Vex775ProLinearMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPILinearMotorBase {
         %<= motor.getDef('Vex775Pro') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/Vex775ProLinearMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Vex775ProLinearMotor.proto
@@ -4,13 +4,14 @@
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
 
-EXTERNPROTO "../protos/WPIMotorBase.proto"
+EXTERNPROTO "../protos/WPILinearMotorBase.proto"
 
 # A WPIMotorBase with the parameters of a Vex 775 Pro motor.
-PROTO Vex775ProMotor [
+PROTO Vex775ProLinearMotor [
     field SFString{"Talon SRX", "Victor SPX", "PWM"} controllerType "Talon SRX"
     field SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     field SFBool inverted FALSE
     field SFString sound "default"
 ]
@@ -18,7 +19,7 @@ PROTO Vex775ProMotor [
 %<
 let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
 >%
-    WPIMotorBase {
-        %<= motor.getDef('Vex775Pro') >%
+    WPILinearMotorBase {
+        %<= motor.getDef('Vex755Pro') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/Vex775ProMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Vex775ProMotor.proto
@@ -15,9 +15,7 @@ PROTO Vex775ProMotor [
     field SFString sound "default"
 ]
 {
-%<
-let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
->%
+    %< let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`)); >%
     WPIMotorBase {
         %<= motor.getDef('Vex775Pro') >%
     }

--- a/plugin/controller/src/webotsFolder/dist/protos/Vex775ProMotor.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/Vex775ProMotor.proto
@@ -1,4 +1,5 @@
 #VRML_SIM R2023b utf8
+# template language: javascript
 
 # license: WPILib BSD
 # license url: https://github.com/wpilibsuite/allwpilib/blob/main/LICENSE.md
@@ -14,16 +15,10 @@ PROTO Vex775ProMotor [
     field SFString sound "default"
 ]
 {
+%<
+let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`));
+>%
     WPIMotorBase {
-        controllerType IS controllerType
-        port IS port
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts 12
-        stallTorqueNewtonMeters 0.71
-        stallCurrentAmps 134
-        freeCurrentAmps 0.7
-        freeSpeedRPM 18730
-        sound IS sound
+        %<= motor.getDef('Vex755Pro') >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/WPILinearMotorBase.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/WPILinearMotorBase.proto
@@ -1,11 +1,12 @@
 #VRML_SIM R2023b utf8
 # template language: javascript
 
-# A RotationalMotor with the properties necessary to construct a WPILib DCMotor
-PROTO WPIMotorBase [
+# A LinearMotor with the properties necessary to construct a WPILib DCMotor
+PROTO WPILinearMotorBase [
     unconnectedField SFString{"Spark Max", "Talon SRX", "Victor SPX", "PWM"} controllerType "Spark Max"
     unconnectedField SFInt32 port 0
     field SFFloat gearing 1
+    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
     unconnectedField SFBool inverted FALSE
     unconnectedField SFFloat nominalVoltageVolts 12
     field SFFloat stallTorqueNewtonMeters 5
@@ -23,7 +24,7 @@ let motor = eval(wbfile.readTextFile(`${context.project_path}protos/wpimotor.js`
 // fields.stallCurrentAmps, fields.freeCurrentAmps, fields.freeSpeedRPM, fields.sound,
 // fields.outputRadiusMeters
 >%
-    RotationalMotor {
+    LinearMotor {
         %<= motor.getBaseDef(fields) >%
     }
 }

--- a/plugin/controller/src/webotsFolder/dist/protos/WPILinearMotorBase.proto
+++ b/plugin/controller/src/webotsFolder/dist/protos/WPILinearMotorBase.proto
@@ -6,7 +6,7 @@ PROTO WPILinearMotorBase [
     unconnectedField SFString{"Spark Max", "Talon SRX", "Victor SPX", "PWM"} controllerType "Spark Max"
     unconnectedField SFInt32 port 0
     field SFFloat gearing 1
-    field SFFloat outputRadiusMeters 0.0254 # 2in diameter
+    unconnectedField SFFloat outputRadiusMeters 0.0254 # 2in diameter
     unconnectedField SFBool inverted FALSE
     unconnectedField SFFloat nominalVoltageVolts 12
     field SFFloat stallTorqueNewtonMeters 5

--- a/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
+++ b/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
@@ -16,13 +16,61 @@
     },
     getDef: function (motorType) {
         const specs = {
-            NEO: {
+            AndyMark9015: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.36,
+                stallCurrentAmps: 71,
+                freeCurrentAmps: 3.7,
+                freeSpeedRPM: 14270
+            },
+            AndyMarkRs775_125: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.28,
+                stallCurrentAmps: 18,
+                freeCurrentAmps: 1.6,
+                freeSpeedRPM: 5800
+            },
+            Bag: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.43,
+                stallCurrentAmps: 53,
+                freeCurrentAmps: 1.8,
+                freeSpeedRPM: 13180
+            },
+            BanebotsRs550: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.38,
+                stallCurrentAmps: 84,
+                freeCurrentAmps: 0.4,
+                freeSpeedRPM: 19000
+            },
+            BanebotsRs775: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.72,
+                stallCurrentAmps: 97,
+                freeCurrentAmps: 2.7,
+                freeSpeedRPM: 13050
+            },
+            CIM: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 2.42,
+                stallCurrentAmps: 133,
+                freeCurrentAmps: 2.7,
+                freeSpeedRPM: 5310
+            },
+            Falcon500: {
                 port: "id",
                 nominalVoltageVolts: 12,
-                stallTorqueNewtonMeters: 2.6,
-                stallCurrentAmps: 105,
-                freeCurrentAmps: 1.8,
-                freeSpeedRPM: 5676
+                stallTorqueNewtonMeters: 4.69,
+                stallCurrentAmps: 257,
+                freeCurrentAmps: 1.5,
+                freeSpeedRPM: 6380
             },
             MiniCIM: {
                 port: "port",
@@ -31,6 +79,38 @@
                 stallCurrentAmps: 89,
                 freeCurrentAmps: 3,
                 freeSpeedRPM: 5840
+            },
+            NEO: {
+                port: "id",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 2.6,
+                stallCurrentAmps: 105,
+                freeCurrentAmps: 1.8,
+                freeSpeedRPM: 5676
+            },
+            NEO550: {
+                port: "id",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.97,
+                stallCurrentAmps: 100,
+                freeCurrentAmps: 1.4,
+                freeSpeedRPM: 11000
+            },
+            RomiBuiltin: {
+                port: "port",
+                nominalVoltageVolts: 4.5,
+                stallTorqueNewtonMeters: 0.1765,
+                stallCurrentAmps: 1.25,
+                freeCurrentAmps: 0.13,
+                freeSpeedRPM: 150
+            },
+            Vex775Pro: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 0.71,
+                stallCurrentAmps: 134,
+                freeCurrentAmps: 0.7,
+                freeSpeedRPM: 18730
             },
         };
         let spec = specs[motorType];

--- a/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
+++ b/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
@@ -1,0 +1,50 @@
+({
+    getBaseDef: function (fields) {
+        let gearing = fields.gearing.value;
+        if (fields.outputRadiusMeters) {
+            gearing = gearing / fields.outputRadiusMeters.value;
+        }
+        return `
+        name "${["DBSim_Motor", fields.controllerType.value, fields.port.value, gearing, fields.inverted.value, fields.nominalVoltageVolts.value, fields.stallTorqueNewtonMeters.value, fields.stallCurrentAmps.value, fields.freeCurrentAmps.value, fields.freeSpeedRPM.value].join('_')}"
+        maxVelocity ${(2 * Math.PI / 60) * fields.freeSpeedRPM.value / gearing}
+        ${fields.outputRadiusMeters ? "maxForce" : "maxTorque"} ${fields.stallTorqueNewtonMeters.value * gearing}
+        # The documentation about the multiplier field is unclear as to how it applies differently to differnt fields / functions.
+        # I think it's best just to implement it ourselves for now.
+        # multiplier ${1 / gearing}
+        ${(fields.sound.value !== "default") ? "soundUrl IS sound" : ""}
+`;
+    },
+    getDef: function (motorType) {
+        const specs = {
+            NEO: {
+                port: "id",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 2.6,
+                stallCurrentAmps: 105,
+                freeCurrentAmps: 1.8,
+                freeSpeedRPM: 5676
+            },
+            MiniCIM: {
+                port: "port",
+                nominalVoltageVolts: 12,
+                stallTorqueNewtonMeters: 1.41,
+                stallCurrentAmps: 89,
+                freeCurrentAmps: 3,
+                freeSpeedRPM: 5840
+            },
+        };
+        let spec = specs[motorType];
+        return `
+        controllerType IS controllerType
+        port IS ${spec.port}
+        gearing IS gearing
+        inverted IS inverted
+        nominalVoltageVolts ${spec.nominalVoltageVolts}
+        stallTorqueNewtonMeters ${spec.stallTorqueNewtonMeters}
+        stallCurrentAmps ${spec.stallCurrentAmps}
+        freeCurrentAmps ${spec.freeCurrentAmps}
+        freeSpeedRPM ${spec.freeSpeedRPM}
+        sound IS sound
+    `;
+    },
+})

--- a/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
+++ b/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
@@ -5,14 +5,14 @@
             gearing = gearing / fields.outputRadiusMeters.value;
         }
         return `
-        name "${["DBSim_Motor", fields.controllerType.value, fields.port.value, gearing, fields.inverted.value, fields.nominalVoltageVolts.value, fields.stallTorqueNewtonMeters.value, fields.stallCurrentAmps.value, fields.freeCurrentAmps.value, fields.freeSpeedRPM.value].join('_')}"
-        maxVelocity ${(2 * Math.PI / 60) * fields.freeSpeedRPM.value / gearing}
-        ${fields.outputRadiusMeters ? "maxForce" : "maxTorque"} ${fields.stallTorqueNewtonMeters.value * gearing}
-        # The documentation about the multiplier field is unclear as to how it applies differently to different fields / functions.
-        # I think it's best just to implement it ourselves for now.
-        # multiplier ${1 / gearing}
-        ${(fields.sound.value !== "default") ? "soundUrl IS sound" : ""}
-`;
+            name "${["DBSim_Motor", fields.controllerType.value, fields.port.value, gearing, fields.inverted.value, fields.nominalVoltageVolts.value, fields.stallTorqueNewtonMeters.value, fields.stallCurrentAmps.value, fields.freeCurrentAmps.value, fields.freeSpeedRPM.value].join('_')}"
+            maxVelocity ${(2 * Math.PI / 60) * fields.freeSpeedRPM.value / gearing}
+            ${fields.outputRadiusMeters ? "maxForce" : "maxTorque"} ${fields.stallTorqueNewtonMeters.value * gearing}
+            # The documentation about the multiplier field is unclear as to how it applies differently to different fields / functions.
+            # I think it's best just to implement it ourselves for now.
+            # multiplier ${1 / gearing}
+            ${(fields.sound.value !== "default") ? "soundUrl IS sound" : ""}
+        `;
     },
     getDef: function (motorType) {
         const specs = {
@@ -115,16 +115,16 @@
         };
         let spec = specs[motorType];
         return `
-        controllerType IS controllerType
-        port IS ${spec.port}
-        gearing IS gearing
-        inverted IS inverted
-        nominalVoltageVolts ${spec.nominalVoltageVolts}
-        stallTorqueNewtonMeters ${spec.stallTorqueNewtonMeters}
-        stallCurrentAmps ${spec.stallCurrentAmps}
-        freeCurrentAmps ${spec.freeCurrentAmps}
-        freeSpeedRPM ${spec.freeSpeedRPM}
-        sound IS sound
-    `;
+            controllerType IS controllerType
+            port IS ${spec.port}
+            gearing IS gearing
+            inverted IS inverted
+            nominalVoltageVolts ${spec.nominalVoltageVolts}
+            stallTorqueNewtonMeters ${spec.stallTorqueNewtonMeters}
+            stallCurrentAmps ${spec.stallCurrentAmps}
+            freeCurrentAmps ${spec.freeCurrentAmps}
+            freeSpeedRPM ${spec.freeSpeedRPM}
+            sound IS sound
+        `;
     },
 })

--- a/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
+++ b/plugin/controller/src/webotsFolder/dist/protos/wpimotor.js
@@ -8,7 +8,7 @@
         name "${["DBSim_Motor", fields.controllerType.value, fields.port.value, gearing, fields.inverted.value, fields.nominalVoltageVolts.value, fields.stallTorqueNewtonMeters.value, fields.stallCurrentAmps.value, fields.freeCurrentAmps.value, fields.freeSpeedRPM.value].join('_')}"
         maxVelocity ${(2 * Math.PI / 60) * fields.freeSpeedRPM.value / gearing}
         ${fields.outputRadiusMeters ? "maxForce" : "maxTorque"} ${fields.stallTorqueNewtonMeters.value * gearing}
-        # The documentation about the multiplier field is unclear as to how it applies differently to differnt fields / functions.
+        # The documentation about the multiplier field is unclear as to how it applies differently to different fields / functions.
         # I think it's best just to implement it ourselves for now.
         # multiplier ${1 / gearing}
         ${(fields.sound.value !== "default") ? "soundUrl IS sound" : ""}

--- a/plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt
+++ b/plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt
@@ -6,6 +6,7 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/project
 EXTERNPROTO "../protos/MiniCIMMotor.proto"
 EXTERNPROTO "../protos/MiniCIMLinearMotor.proto"
 EXTERNPROTO "../protos/PoweredHingeJoint.proto"
+EXTERNPROTO "../protos/PoweredSliderJoint.proto"
 EXTERNPROTO "../protos/WPIQuadratureEncoder.proto"
 
 WorldInfo {
@@ -33,11 +34,11 @@ DEF ROBOT Robot {
   children [
     Solid {
       children [
-        SliderJoint {
+        PoweredSliderJoint {
           jointParameters JointParameters {
             maxStop 1
           }
-          device [
+          devices [
             MiniCIMLinearMotor {
               controllerType "PWM"
               port 4

--- a/plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt
+++ b/plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt
@@ -4,6 +4,7 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/project
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/backgrounds/protos/TexturedBackground.proto"
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
 EXTERNPROTO "../protos/MiniCIMMotor.proto"
+EXTERNPROTO "../protos/MiniCIMLinearMotor.proto"
 EXTERNPROTO "../protos/PoweredHingeJoint.proto"
 EXTERNPROTO "../protos/WPIQuadratureEncoder.proto"
 
@@ -32,6 +33,41 @@ DEF ROBOT Robot {
   children [
     Solid {
       children [
+        SliderJoint {
+          jointParameters JointParameters {
+            maxStop 1
+          }
+          device [
+            MiniCIMLinearMotor {
+              controllerType "PWM"
+              port 4
+              gearing 7
+              outputRadiusMeters 0.0127
+            }
+            WPIQuadratureEncoder {
+              channelA 8
+              channelB 9
+            }
+            Brake {
+            }
+          ]
+          endPoint DEF ELEVATOR Solid {
+            translation 0 0 0.17
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  metalness 0.5
+                }
+                geometry DEF ELEVATOR_GEOM Box {
+                  size 0.05 0.3 0.3
+                }
+              }
+            ]
+            boundingObject USE ELEVATOR_GEOM
+            physics Physics {
+            }
+          }
+        }
         PoweredHingeJoint {
           devices [
             MiniCIMMotor {


### PR DESCRIPTION
- Extract common motor proto def into wpimotor.js.
- Add WPILinearMotorBase.proto, and *LinearMotor.proto.
- Extract motor specs into wpimotor.js.
- Add PoweredSliderJoint.proto.
- Add elevator to robot.
- Add simple smoke test.