### PR TITLE
Fix-file-locking

### DIFF
--- a/example/src/systemTest/java/frc/robot/SystemTestRobot.java
+++ b/example/src/systemTest/java/frc/robot/SystemTestRobot.java
@@ -6,9 +6,7 @@ import org.carlmontrobotics.libdeepbluesim.WebotsSimulator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.io.FileNotFoundException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
@@ -18,11 +16,9 @@ import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 public class SystemTestRobot {
 
     @Test
-    void testDrivesToLocationAndElevatesInAutonomous()
-            throws Exception {
-        try (var robot = new Robot();
-                var manager =
-                        new WebotsSimulator("Webots/worlds/DBSExample.wbt")) {
+    void testDrivesToLocationAndElevatesInAutonomous() throws Exception {
+        try (var manager = new WebotsSimulator("Webots/worlds/DBSExample.wbt",
+                Robot.class)) {
             manager.atSec(0.0, s -> {
                 s.enableAutonomous();
             }).atSec(1.0, s -> {
@@ -51,18 +47,16 @@ public class SystemTestRobot {
                         Units.radiansToDegrees(
                                 s.angularVelocity("ROBOT").getAngle()),
                         1, "Robot close to target angular velocity");
-            }).run(robot);
+            }).run();
         }
     }
 
     private volatile boolean stoppedTryingToTurn = false;
 
     @Test
-    void testCanBeRotatedInPlaceInTeleop()
-            throws Exception {
-        try (var robot = new Robot();
-                var manager =
-                        new WebotsSimulator("Webots/worlds/DBSExample.wbt")) {
+    void testCanBeRotatedInPlaceInTeleop() throws Exception {
+        try (var manager = new WebotsSimulator("Webots/worlds/DBSExample.wbt",
+                Robot.class)) {
             manager.atSec(0.0, s -> {
                 s.enableTeleop();
                 DriverStationSim.setJoystickAxisCount(0, 2);
@@ -103,7 +97,7 @@ public class SystemTestRobot {
                         Units.radiansToDegrees(
                                 s.angularVelocity("ROBOT").getAngle()),
                         1, "Robot close to target angular velocity");
-            }).run(robot);
+            }).run();
         }
     }
 }

--- a/example/src/systemTest/java/frc/robot/SystemTestRobot.java
+++ b/example/src/systemTest/java/frc/robot/SystemTestRobot.java
@@ -19,7 +19,7 @@ public class SystemTestRobot {
 
     @Test
     void testDrivesToLocationAndElevatesInAutonomous()
-            throws TimeoutException, FileNotFoundException {
+            throws Exception {
         try (var robot = new Robot();
                 var manager =
                         new WebotsSimulator("Webots/worlds/DBSExample.wbt")) {
@@ -59,7 +59,7 @@ public class SystemTestRobot {
 
     @Test
     void testCanBeRotatedInPlaceInTeleop()
-            throws TimeoutException, FileNotFoundException {
+            throws Exception {
         try (var robot = new Robot();
                 var manager =
                         new WebotsSimulator("Webots/worlds/DBSExample.wbt")) {

--- a/plugin/src/main/groovy/org/carlmontrobotics/deepbluesim/gradle/DeepBlueSimExtension.java
+++ b/plugin/src/main/groovy/org/carlmontrobotics/deepbluesim/gradle/DeepBlueSimExtension.java
@@ -1,16 +1,9 @@
 package org.carlmontrobotics.deepbluesim.gradle;
 
 import java.io.File;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Semaphore;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -90,15 +83,6 @@ public class DeepBlueSimExtension {
         }
     }
 
-    // DeepBlueSim uses WPI's HAL sim websocket server extension and only one process can be started
-    // with that extension at a time, presumably because it listens on a TCP port. Gradle can create
-    // multiple processes each with multiple threads each with different instances of this class. To
-    // ensure only one DeepBlueSim test task is running at a time, we use a file lock to ensure
-    // there is only one gradle process and a semaphore to ensure there is only one thread within
-    // that process that is running a DeepBlueSim test task.
-    private static Semaphore semaphore = new Semaphore(1);
-    private static volatile FileLock fileLock = null;
-
     /**
      * Configures a task so it can use the specificed WPILib simulation extensions.
      * 
@@ -128,7 +112,6 @@ public class DeepBlueSimExtension {
             @Override
             public void execute(Task task) {
                 try {
-                    var logger = project.getLogger();
                     File ldpath = extract.get().getDestinationDirectory().get().getAsFile();
                     List<HalSimPair> halSimPairs = sim.getHalSimLocations(List.of(ldpath), debug);
                     Map<String, ?> env = sim.getEnvironment();
@@ -155,55 +138,12 @@ public class DeepBlueSimExtension {
                         System.out.println(
                                 "That can be found at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads");
                     }
-                    logger.debug("deepbluesim is waiting for semaphore");
-                    semaphore.acquire();
-                    logger.debug("deepbluesim acquired semaphore");
-                    if (fileLock == null) {
-                        var lockFilePath =
-                                Path.of(System.getProperty("java.io.tmpdir"),
-                                        "deepbluesim.lock");
-                        var channel = FileChannel.open(lockFilePath,
-                                StandardOpenOption.CREATE,
-                                StandardOpenOption.WRITE,
-                                StandardOpenOption.TRUNCATE_EXISTING);
-                        fileLock = channel.tryLock();
-                        while (fileLock == null) {
-                            logger.debug(
-                                    "deepbluesim is waiting for file lock. See {}",
-                                    lockFilePath);
-                            Thread.sleep(10000);
-                            fileLock = channel.tryLock();
-                        }
-                        logger.debug("deepbluesim acquired file lock.");
-                        // The lock will be released when the JVM exits.
-                        channel.write(
-                                ByteBuffer.wrap("Locked by deepbluesim %Tc"
-                                        .formatted(Calendar.getInstance())
-                                        .getBytes()));
-                    }
+
                 } catch (Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         });
-        t.doLast(new Action<Task>() {
-
-            @Override
-            public void execute(Task task) {
-                var logger = project.getLogger();
-                logger.debug("deepbluesim is releasing semaphore");
-                try {
-                    logger.debug("deepbluesim is releasing file lock");
-                    fileLock.release();
-                } catch (Exception ex) {
-                    throw new RuntimeException(ex);
-                } finally {
-                    fileLock = null;
-                }
-                semaphore.release();
-            }
-        });
-
     }
 
     private void configureExecutableNatives(Task tt, Provider<ExtractNativeJavaArtifacts> extract) {

--- a/tests/src/systemTest/java/frc/robot/DBSExampleTest.java
+++ b/tests/src/systemTest/java/frc/robot/DBSExampleTest.java
@@ -18,7 +18,7 @@ import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 public class DBSExampleTest {
     @Test
     void testDrivesToLocationAndElevatesInAutonomous()
-            throws TimeoutException, FileNotFoundException {
+            throws Exception {
         try (var robot = new DBSExampleRobot();
                 var manager = new WebotsSimulator(
                         "../plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt")) {
@@ -58,7 +58,7 @@ public class DBSExampleTest {
 
     @Test
     void testCanBeRotatedInPlaceInTeleop()
-            throws TimeoutException, FileNotFoundException {
+            throws Exception {
         try (var robot = new DBSExampleRobot();
                 var manager = new WebotsSimulator(
                         "../plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt")) {

--- a/tests/src/systemTest/java/frc/robot/DBSExampleTest.java
+++ b/tests/src/systemTest/java/frc/robot/DBSExampleTest.java
@@ -5,23 +5,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.carlmontrobotics.libdeepbluesim.WebotsSimulator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.FileNotFoundException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 
 @Timeout(value = 30, unit = TimeUnit.MINUTES)
+@ResourceLock("WebotsSimulator")
 public class DBSExampleTest {
     @Test
-    void testDrivesToLocationAndElevatesInAutonomous()
-            throws Exception {
-        try (var robot = new DBSExampleRobot();
-                var manager = new WebotsSimulator(
-                        "../plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt")) {
+    void testDrivesToLocationAndElevatesInAutonomous() throws Exception {
+        try (var manager = new WebotsSimulator(
+                "../plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt",
+                DBSExampleRobot.class)) {
             manager.atSec(0.0, s -> {
                 s.enableAutonomous();
             }).atSec(1.0, s -> {
@@ -50,18 +49,17 @@ public class DBSExampleTest {
                         Units.radiansToDegrees(
                                 s.angularVelocity("ROBOT").getAngle()),
                         1, "Robot close to target angular velocity");
-            }).run(robot);
+            }).run();
         }
     }
 
     private volatile boolean stoppedTryingToTurn = false;
 
     @Test
-    void testCanBeRotatedInPlaceInTeleop()
-            throws Exception {
-        try (var robot = new DBSExampleRobot();
-                var manager = new WebotsSimulator(
-                        "../plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt")) {
+    void testCanBeRotatedInPlaceInTeleop() throws Exception {
+        try (var manager = new WebotsSimulator(
+                "../plugin/controller/src/webotsFolder/dist/worlds/DBSExample.wbt",
+                DBSExampleRobot.class)) {
             manager.atSec(0.0, s -> {
                 s.enableTeleop();
                 DriverStationSim.setJoystickAxisCount(0, 2);
@@ -102,7 +100,7 @@ public class DBSExampleTest {
                         Units.radiansToDegrees(
                                 s.angularVelocity("ROBOT").getAngle()),
                         1, "Robot close to target angular velocity");
-            }).run(robot);
+            }).run();
         }
     }
 }

--- a/tests/src/systemTest/java/frc/robot/PWMMotorControllerTest.java
+++ b/tests/src/systemTest/java/frc/robot/PWMMotorControllerTest.java
@@ -16,7 +16,7 @@ import edu.wpi.first.math.util.Units;
 public class PWMMotorControllerTest {
     @Test
     void testShaftRotatesInAutonomous()
-            throws TimeoutException, FileNotFoundException {
+            throws Exception {
         // TODO: Fix the expected values to be physically correct and then fix PWMMotorMediator to
         // pass the test.
         try (var robot = new PWMMotorControllerRobot();

--- a/tests/src/systemTest/java/frc/robot/PWMMotorControllerTest.java
+++ b/tests/src/systemTest/java/frc/robot/PWMMotorControllerTest.java
@@ -5,23 +5,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.carlmontrobotics.libdeepbluesim.WebotsSimulator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.FileNotFoundException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import edu.wpi.first.math.util.Units;
 
 @Timeout(value = 30, unit = TimeUnit.MINUTES)
+@ResourceLock("WebotsSimulator")
 public class PWMMotorControllerTest {
     @Test
-    void testShaftRotatesInAutonomous()
-            throws Exception {
+    void testShaftRotatesInAutonomous() throws Exception {
         // TODO: Fix the expected values to be physically correct and then fix PWMMotorMediator to
         // pass the test.
-        try (var robot = new PWMMotorControllerRobot();
-                var manager = new WebotsSimulator(
-                        "../plugin/controller/src/webotsFolder/dist/worlds/PWMMotorController.wbt")) {
+        try (var manager = new WebotsSimulator(
+                "../plugin/controller/src/webotsFolder/dist/worlds/PWMMotorController.wbt",
+                PWMMotorControllerRobot.class)) {
             manager.atSec(0.0, s -> {
                 s.enableAutonomous();
             }).atSec(1.0, s -> {
@@ -40,7 +39,7 @@ public class PWMMotorControllerTest {
                 assertEquals(-28.8,
                         Units.radiansToDegrees(s.rotation("SHAFT").getZ()),
                         45.0, "Shaft close to target rotation");
-            }).run(robot);
+            }).run();
         }
     }
 }


### PR DESCRIPTION
Move file locking to WebotsSimulator to fix #90  and ensure endCompetition() is always called to at least partially fix #85.

Also makes WebotsSimulator constructor take the robot class instead of making the run() method take a robot instance. That helps discourage the test code from instantiating a robot because doing so might cause WPILib to try to start a NetworkTables server when another test already has one running.