### PR TITLE
Prevent VSCode from trying to change the indentation level of files.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "java.configuration.updateBuildConfiguration": "interactive",
     "java.format.settings.url": "https://raw.githubusercontent.com/wpilibsuite/styleguide/main/ide/eclipse-java-google-style.xml",
     "editor.formatOnSaveMode": "modificationsIfAvailable",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.detectIndentation": false
 }


### PR DESCRIPTION
Without this I find that I frequently (but unpredictably) need to "change the tab display size" back to the default of 4.