### PR TITLE
Add VSCode native debug launcher that attaches to java process.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,28 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "(gdb) Attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${env:HOME}/wpilib/2024/jdk/bin/java",
+            "sourceFileMap": {
+                "/work/": "${env:HOME}/git/allwpilib/"
+            },
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "type": "java",
             "name": "Launch Extern Controller",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
                 "program": "${env:PUBLIC}\\wpilib\\2024\\jdk\\bin\\java"
             },
             "sourceFileMap": {
-                "/work/": "${env:HOME}/git/allwpilib/"
+                "/work/": "${input:wpilibSrcPath}/"
             },
             "MIMode": "gdb",
             "setupCommands": [
@@ -57,6 +57,14 @@
             },
             "args": "--no-robot-code",
             "cwd": "${workspaceFolder}/example/Webots/controllers/DeepBlueSim"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "wpilibSrcPath",
+            "type": "promptString",
+            "description": "The path to the wpilib source code (no trailing slash)",
+            "default": "${workspaceFolder}/../allwpilib"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,9 @@
             "type": "cppdbg",
             "request": "attach",
             "program": "${env:HOME}/wpilib/2024/jdk/bin/java",
+            "windows": {
+                "program": "${env:PUBLIC}\\wpilib\\2024\\jdk\\bin\\java"
+            },
             "sourceFileMap": {
                 "/work/": "${env:HOME}/git/allwpilib/"
             },


### PR DESCRIPTION
Note that this includes PR #114.

Other notes:

In my experience on linux searching for "executor" brings up  the "Gradle Test Executor" java process of interest when debugging tests hanging in native code.

The sourceFileMap assumes that that wpilib source is installed under $HOME/git/allwpilib. If it isn't, you can still see stack traces, you just won't be able to see the wpilib source.

The "program" location probably needs a windows specific version, maybe with ${env:HOME} replaced with ${env:ALLUSERSPROFILE} or "C:\Users\Public"?