### PR TITLE
*Start to* workaround HALSimWS SimDevice deadlocks.

### DIFF
--- a/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/WebotsSupervisor.java
+++ b/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/WebotsSupervisor.java
@@ -103,8 +103,10 @@ public final class WebotsSupervisor {
      * @param robot The robot to report on
      * @param basicTimeStep The timestep to pass to {@link Supervisor#step(int)} to advance the
      *        simulation
+     * @param connectionCloser code to run to close open network connections
      */
-    public static void init(Supervisor robot, int basicTimeStep) {
+    public static void init(Supervisor robot, int basicTimeStep,
+            Runnable connectionCloser) {
         // Use the default NetworkTables instance to coordinate with robot code
         inst = NetworkTableInstance.getDefault();
 
@@ -204,6 +206,7 @@ public final class WebotsSupervisor {
                         closePublishers();
                         waitUntilFlushed();
                         inst.stopClient();
+                        connectionCloser.run();
                         inst.close();
                         if (delayer != null) {
                             delayer.cancel();

--- a/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/WebotsSupervisor.java
+++ b/plugin/controller/src/main/java/org/carlmontrobotics/deepbluesim/WebotsSupervisor.java
@@ -98,6 +98,8 @@ public final class WebotsSupervisor {
 
     private static boolean gotSimMode;
 
+    private static final long minQuietTimeMs = 500;
+
     private static final Timer delayer = new Timer();
     private static volatile long lastMsgTimeMs = -1;
 
@@ -357,8 +359,6 @@ public final class WebotsSupervisor {
             }
         });
     }
-
-    private static final long minQuietTimeMs = 500;
 
     private static void sendCompletedOnceHALSimIsQuiet() {
         // To workaround https://github.com/wpilibsuite/allwpilib/issues/6842, wait until HALSim has


### PR DESCRIPTION
Includes PR #114 and PR #117. Fixes issue #113.

The critical change here is calling waitForUserToStart() *before* creating the robot. That gives the controller's HALSimWS client a chance to connect before the SimDevices are created. Before that change, I'd get a deadlock at ~1/7 of the time. With that change, I've run over 137 times in a row without a deadlock.

