### PR TITLE
Make tests repeatable and more accurate.

### DIFF
--- a/plugin/libdeepbluesim/src/main/java/org/carlmontrobotics/libdeepbluesim/WebotsSimulator.java
+++ b/plugin/libdeepbluesim/src/main/java/org/carlmontrobotics/libdeepbluesim/WebotsSimulator.java
@@ -86,8 +86,7 @@ public class WebotsSimulator implements AutoCloseable {
     private final StringPublisher simModePublisher;
 
     // We'll use this to run all NT listener callbacks sequentially on a single separate thread.
-    private final ExecutorService listenerCallbackExecutor =
-            Executors.newSingleThreadExecutor();
+    private ExecutorService listenerCallbackExecutor;
 
     // Use these to control NetworkTables logging.
     // - ntLoglevel = 0 means no NT logging
@@ -140,6 +139,13 @@ public class WebotsSimulator implements AutoCloseable {
         } catch (InterruptedException | IOException ex) {
             LOG.log(Level.ERROR, "Unable to acquire file lock", ex);
         }
+    }
+
+    private void runOnExecutorThread(Runnable r) {
+        if (listenerCallbackExecutor.isShutdown()) {
+            return;
+        }
+        listenerCallbackExecutor.execute(r);
     }
 
     private static synchronized void acquireFileLock()
@@ -326,7 +332,7 @@ public class WebotsSimulator implements AutoCloseable {
         inst.addListener(statusSubscriber,
                 EnumSet.of(Kind.kValueRemote, Kind.kImmediate), (event) -> {
                     final var eventValue = event.valueData.value.getString();
-                    listenerCallbackExecutor.execute(() -> {
+                    runOnExecutorThread(() -> {
                         LOG.log(Level.DEBUG, "In listener, status = {0}",
                                         eventValue);
                         if (!eventValue.equals(
@@ -433,7 +439,7 @@ public class WebotsSimulator implements AutoCloseable {
                     LOG.log(Level.DEBUG,
                             "In simTimeSec value changed callback");
                     final var eventValue = value.getDouble();
-                    listenerCallbackExecutor.execute(() -> {
+                    runOnExecutorThread(() -> {
                         LOG.log(Level.DEBUG, "Got simTimeSec value of {0}",
                                 eventValue);
                         if (eventValue < 0.0) {
@@ -491,7 +497,7 @@ public class WebotsSimulator implements AutoCloseable {
 
         waitForHALSimWSConnection();
 
-        listenerCallbackExecutor.execute(() -> {
+        runOnExecutorThread(() -> {
             simTimeSec = 0.0;
             sendRobotTime();
         });
@@ -506,14 +512,12 @@ public class WebotsSimulator implements AutoCloseable {
         inst.addListener(statusSubscriber,
                 EnumSet.of(Kind.kValueRemote, Kind.kImmediate), (event) -> {
                     final var eventValue = event.valueData.value.getString();
-                    listenerCallbackExecutor.execute(() -> {
-                        LOG.log(Level.DEBUG, "In listener, status = {0}",
-                                eventValue);
-                        if (!eventValue.equals(
-                                NTConstants.STATUS_HALSIMWS_CONNECTED_VALUE))
-                            return;
-                        halSimWSConnected.complete(null);
-                    });
+                    LOG.log(Level.DEBUG, "In listener, status = {0}",
+                            eventValue);
+                    if (!eventValue.equals(
+                            NTConstants.STATUS_HALSIMWS_CONNECTED_VALUE))
+                        return;
+                    halSimWSConnected.complete(null);
                 });
 
         requestPublisher.set(NTConstants.REQUEST_HALSIMWS_CONNECTION_VERB);
@@ -790,6 +794,8 @@ public class WebotsSimulator implements AutoCloseable {
     public void run() throws InstantiationException, IllegalAccessException,
             InvocationTargetException, NoSuchMethodException,
             SecurityException, TimeoutException {
+        listenerCallbackExecutor = Executors.newSingleThreadExecutor();
+
         endCompetitionCalled = false;
         // HAL must be initialized or SmartDashboard might not work.
         HAL.initialize(500, 0);
@@ -821,13 +827,23 @@ public class WebotsSimulator implements AutoCloseable {
                 });
             }
 
-            // Run the onInited callbacks once.
-            // Note: the offset is -period so they are run before other WPILib periodic methods
+            // Schedule the onInited callbacks to be run once. Note: the offset is -period so they
+            // are run before
+            // other WPILib periodic methods the 1e-6 is so that it isn't scheduled for a timstamp
+            // of exactly 0.0 because that is a special value that causes startCompetition() to end.
             robot.addPeriodic(this::runRobotInitedCallbacksOnce,
-                    robot.getPeriod(), -robot.getPeriod());
+                    robot.getPeriod(), -robot.getPeriod() + 1e-6);
+
+            // Step forward far enough that the onInited callbacks are run. This needs to happen on
+            // a separate thread because they won't be run until startCompetition() has been called
+            // and startCompetition() will block until timing advances.
+            runOnExecutorThread(() -> {
+                LOG.log(Level.INFO, "Calling stepTiming()");
+                SimHooks.stepTiming(2e-6);
+                LOG.log(Level.INFO, "Called stepTiming()");
+            });
 
             this.endNotifier = endNotifier;
-            SimHooks.resumeTiming();
             isRobotCodeRunning = true;
             try {
                 robot.startCompetition();
@@ -835,6 +851,7 @@ public class WebotsSimulator implements AutoCloseable {
                 // Always call endCompetition() so that WPILib's notifier is stopped. If it isn't
                 // future tests will hang on calls to stepTiming().
                 endCompetition(robot);
+                blockWhileShuttingDownExecutor();
             }
             if (runExitThrowable != null) {
                 throw new RuntimeException(runExitThrowable);
@@ -850,6 +867,27 @@ public class WebotsSimulator implements AutoCloseable {
         }
     }
 
+    private void blockWhileShuttingDownExecutor() {
+        if (listenerCallbackExecutor.isShutdown()) {
+            return;
+        }
+        try {
+            listenerCallbackExecutor.shutdown();
+            if (!listenerCallbackExecutor.awaitTermination(10,
+                    TimeUnit.SECONDS)) {
+                throw new TimeoutException(
+                        "Timed out awaiting termination of callback executor");
+            }
+            // This needs to be done after shutting down the listenerCallbackExecutor
+            // because some callbacks create Watchers and Watcher is not thread-safe.
+            Watcher.closeAll();
+        } catch (SecurityException | InterruptedException
+                | TimeoutException ex) {
+            throw new RuntimeException("Could not shutdown callback executor.",
+                    ex);
+        }
+    }
+
     private Notifier endNotifier = null;
 
     /**
@@ -857,21 +895,15 @@ public class WebotsSimulator implements AutoCloseable {
      */
     public void close() {
         LOG.log(Level.DEBUG, "Closing WebotsSimulator");
+        blockWhileShuttingDownExecutor();
         requestPublisher.close();
         statusSubscriber.close();
-        Watcher.closeAll();
         inst.close();
         inst.stopServer();
         pauser.close();
         if (timeSyncDevice != null) {
             timeSyncDevice.close();
         }
-        try {
-            listenerCallbackExecutor.shutdown();
-        } catch (SecurityException ex) {
-            LOG.log(Level.ERROR, "Could not shutdown callback executor.", ex);
-        }
-
         LOG.log(Level.DEBUG, "Done closing WebotsSimulator");
     }
 }

--- a/plugin/libdeepbluesim/src/main/java/org/carlmontrobotics/libdeepbluesim/WebotsSimulator.java
+++ b/plugin/libdeepbluesim/src/main/java/org/carlmontrobotics/libdeepbluesim/WebotsSimulator.java
@@ -828,9 +828,9 @@ public class WebotsSimulator implements AutoCloseable {
             }
 
             // Schedule the onInited callbacks to be run once. Note: the offset is -period so they
-            // are run before
-            // other WPILib periodic methods the 1e-6 is so that it isn't scheduled for a timstamp
-            // of exactly 0.0 because that is a special value that causes startCompetition() to end.
+            // are run before other WPILib periodic methods the 1e-6 is so that it isn't scheduled
+            // for a timestamp of exactly 0.0 because that is a special value that causes
+            // startCompetition() to end.
             robot.addPeriodic(this::runRobotInitedCallbacksOnce,
                     robot.getPeriod(), -robot.getPeriod() + 1e-6);
 

--- a/tests/src/systemTest/java/frc/robot/MotorControllerTest.java
+++ b/tests/src/systemTest/java/frc/robot/MotorControllerTest.java
@@ -112,7 +112,7 @@ public class MotorControllerTest {
 
     private static double computeAngleRadians(DCMotor gearMotor, double moiKgM2,
             double throttle, double initialSpeedRadPerSec,
-                    double initialAngleRad, double tSecs) {
+            double initialAngleRad, double tSecs) {
         double timeConstantSecs = computeTimeConstantSecs(gearMotor, moiKgM2);
         double targetSpeedRadPerSec = throttle * gearMotor.nominalVoltageVolts
                 * gearMotor.KvRadPerSecPerVolt;
@@ -160,8 +160,7 @@ public class MotorControllerTest {
             double moiKgM2, double tSecs) {
         if (tSecs <= tMotorStartsSecs) {
             return 0.0;
-        }
-        if (tSecs <= tMotorStopsSecs) {
+        } else if (tSecs <= tMotorStopsSecs) {
             return computeAngleRadians(gearMotor, moiKgM2, 0.5, 0, 0,
                     tSecs - tMotorStartsSecs);
         }
@@ -178,7 +177,7 @@ public class MotorControllerTest {
 
     private static double computeFlywheelThickness(DCMotor gearMotor,
             double flywheelRadiusMeters, double flywheelDensityKgPerM3,
-                    double desiredTimeConstantSecs) {
+            double desiredTimeConstantSecs) {
         // for a time constant of t_c seconds:
         // t_c = R*J*k_v/k_T
         // J = t_c*k_T/(k_v*R)


### PR DESCRIPTION
- Remove variable delay that could result in periodic methods being run at slightly different times.
- Use the actual gearing and flywheel height from the world instead of the theoretical one to avoid rounding errors.